### PR TITLE
Fix: Unescaped JSON Output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "unescape",
 ]
 
 [[package]]
@@ -523,6 +524,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1.38.0", features = ["full"] }
 dbus-tokio = "0.7.6"
 once_cell = "1.19.0"
 thiserror = "1.0.61"
+unescape = "0.1.0"
 
 [profile.release]
 opt-level = "z"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::config::{Config, PositionMode, ScrollMode as ConfigScrollMode};
 use crate::player::PlayerState;
 use crate::scroll::{ScrollMode, ScrollState, scroll};
+use unescape::unescape;
 
 fn format_metadata(format: &str, title: &str, artist: &str, album: &str) -> String {
     format
@@ -24,12 +25,7 @@ fn get_icon(
         .iter()
         .find(|(key, _)| service.contains(*key))
         .map(|(_, icon)| icon.as_str())
-        .unwrap_or_else(|| {
-            icon_format
-                .get("404")
-                .map(|s| s.as_str())
-                .unwrap_or("")
-        });
+        .unwrap_or_else(|| icon_format.get("404").map(|s| s.as_str()).unwrap_or(""));
 
     let play_icon = if no_play_icon {
         ""
@@ -110,7 +106,7 @@ pub fn print_status(
         .to_string();
 
         if *last_output != json_output {
-            println!("{}", json_output);
+            println!("{}", unescape(&json_output).unwrap());
             *last_output = json_output;
         }
         return;
@@ -162,7 +158,7 @@ pub fn print_status(
     .to_string();
 
     if *last_output != json_output {
-        println!("{}", json_output);
+        println!("{}", unescape(&json_output).unwrap());
         *last_output = json_output;
     }
 }


### PR DESCRIPTION
Greetings

This project still fulfills my needs! Thanks once again :) I noticed a small issue and this PR is my attempt to fix it. 

The string output kept getting double-escaped. Because of this, parsing `--tooltip-format "{artist}\n{album}"`, results in `{artist}\\n{album}` instead of `{artist}\n{album}`. This confuses waybar as well. 

This is probably a behaviour of `serde_json::json!()`. Fixed by using [`unescape::unescape`](https://crates.io/crates/unescape)

