### PR TITLE
feat: add ability to switch player icons

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,9 @@ pub struct Config {
     /// Disable icon in output
     #[arg(long = "no-icon", default_value_t = false, action = clap::ArgAction::SetTrue)]
     pub no_icon: bool,
+    /// Switch play/pause icon in output
+    #[arg(long = "switch-icons", default_value_t = false, action = clap::ArgAction::SetTrue)]
+    pub switch_icons: bool,
     /// Position style: "increasing" or "remaining"
     #[arg(long = "position-mode", default_value = "increasing")]
     pub position_mode: PositionMode,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,7 @@ fn get_icon(
     player_state: &PlayerState,
     icon_format: &HashMap<String, String>,
     no_play_icon: bool,
+    switch_icons: bool,
 ) -> String {
     let service = player_state.get_service().unwrap_or("").to_lowercase();
 
@@ -29,10 +30,16 @@ fn get_icon(
 
     let play_icon = if no_play_icon {
         ""
-    } else if player_state.playing {
-        ""
+    } else if switch_icons {
+        match player_state.playing {
+            true => "",
+            false => "",
+        }
     } else {
-        ""
+        match player_state.playing {
+            true => "",
+            false => "",
+        }
     };
 
     if !service_icon.is_empty() {
@@ -139,7 +146,7 @@ pub fn print_status(
     } else if config.no_icon {
         format!("{}{}", scrolled_text, position_text)
     } else {
-        let icon = get_icon(player_state, &config.icon_format, config.no_status_icon);
+        let icon = get_icon(player_state, &config.icon_format, config.no_status_icon, config.switch_icons);
         format!("{} {}{}", icon, scrolled_text, position_text)
     };
 


### PR DESCRIPTION
Hi!

Really like your project!
Ive added a little feature, the ability to switch the player icon at the beginning of the string.
I was used to seeing the "pause" icon if music was playing and the "play" icon if music was paused and couldnt get used to it being the other way around.
